### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ If you experience problems with SeaSnake, `log them on GitHub`_. If you
 want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
 .. _BeeWare suite: http://pybee.org
-.. _Read The Docs: http://seasnake.readthedocs.org
+.. _Read The Docs: https://seasnake.readthedocs.io
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
 .. _BeeWare Users Mailing list: https://groups.google.com/forum/#!forum/beeware-users
 .. _BeeWare Developers Mailing list: https://groups.google.com/forum/#!forum/beeware-developers

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,7 +36,7 @@ SeaSnake is part of the `BeeWare suite`_. You can talk to the community through:
  * The `BeeWare Developers Mailing list`_, for discussing the development of new features in the BeeWare suite, and ideas for new tools for the suite.
 
 .. _BeeWare suite: http://pybee.org
-.. _Read The Docs: http://seasnake.readthedocs.org
+.. _Read The Docs: https://seasnake.readthedocs.io
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
 .. _BeeWare Users Mailing list: https://groups.google.com/forum/#!forum/beeware-users
 .. _BeeWare Developers Mailing list: https://groups.google.com/forum/#!forum/beeware-developers


### PR DESCRIPTION
As per their email ‘Changes to project subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified. `https://seasnake.readthedocs.io/` is a 404, seems like the project's Read the Docs isn't set up.